### PR TITLE
fixing sign on update clipping

### DIFF
--- a/lib/rl.js
+++ b/lib/rl.js
@@ -1237,7 +1237,7 @@ SimpleReinforceAgent.prototype = {
         }
         var update = - (V - b);
         if(update > 0.1) { update = 0.1; }
-        if(update < 0.1) { update = -0.1; }
+        if(update < -0.1) { update = -0.1; }
         this.baselineOutputs[t].dw[0] += update;
         baselineMSE += (V - b) * (V - b);
         vs.push(V);
@@ -1364,7 +1364,7 @@ RecurrentReinforceAgent.prototype = {
         }
         var update = - (V - b);
         if(update > 0.1) { update = 0.1; }
-        if(update < 0.1) { update = -0.1; }
+        if(update < -0.1) { update = -0.1; }
         this.baselineOutputs[t].dw[0] += update;
         baselineMSE += (V-b)*(V-b);
         vs.push(V);


### PR DESCRIPTION
Should the baseline update clipping be setting everything below .1 to -.1? This doesn't match the actor's update clipping.
