### PR TITLE
Changed dependencies from HTTP to HTTPS

### DIFF
--- a/gridworld_dp.html
+++ b/gridworld_dp.html
@@ -14,8 +14,8 @@
   <script src="external/jquery-ui.min.js"></script>
 
   <!-- bootstrap -->
-  <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-  <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- d3js -->
   <script type="text/javascript" src="external/d3.min.js"></script>
@@ -418,7 +418,7 @@
       (function () {
         var script = document.createElement("script");
         script.type = "text/javascript";
-        script.src  = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+        script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
         document.getElementsByTagName("head")[0].appendChild(script);
         jaxrendered = true;
       })();


### PR DESCRIPTION
Bootstrap and MathJax are blocked by browsers because they are not over HTTPS.